### PR TITLE
fixes: #91 Add functionality from Recursive Paginator

### DIFF
--- a/src/Recursive/RecursiveParser.php
+++ b/src/Recursive/RecursiveParser.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Xparse\Parser\Recursive;
+
+use Exception;
+use Generator;
+use InvalidArgumentException;
+use IteratorAggregate;
+use PhpParser\Node\Expr\Array_;
+use Xparse\ElementFinder\ElementFinderInterface;
+use Xparse\Parser\ParserInterface;
+
+class RecursiveParser implements IteratorAggregate
+{
+    /**
+     * @var array<string>
+     */
+    private array $links = [];
+
+    /**
+     * @var ParserInterface
+     */
+    private ParserInterface $parser;
+
+    /**
+     * @var string[]
+     */
+    private array $expressions = [];
+
+
+    /**
+     * @param ParserInterface $parser
+     * @param string[] $expressions
+     * @param string[] $links
+     * @throws InvalidArgumentException
+     */
+    public function __construct(ParserInterface $parser, array $expressions, array $links = [])
+    {
+        $this->parser = $parser;
+        $this->expressions = $expressions;
+        $this->links = $links;
+    }
+
+    /**
+     * @return ElementFinderInterface[]|Generator
+     * @throws Exception
+     */
+    final public function getIterator(): Generator
+    {
+        $left = $this->links;
+        $done = [];
+        while ($left !== []) {
+            $left = array_unique(array_diff($left, $done));
+            foreach ($left as $index => $link) {
+                unset($left[$index]);
+                $done[] = $link;
+                $page = $this->parser->get($link);
+                $nextLinks = [];
+                foreach ($this->expressions as $expression) {
+                    $nextLinks = array_merge($nextLinks, $page->value($expression)->all());
+                }
+                $left = array_merge($left, $nextLinks);
+                yield $page;
+            }
+        }
+    }
+}

--- a/tests/Dummy/LocalParser.php
+++ b/tests/Dummy/LocalParser.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Xparse\Parser\Dummy;
+
+use Xparse\ElementFinder\ElementFinder;
+use Xparse\ElementFinder\ElementFinderInterface;
+use Xparse\Parser\ParserInterface;
+
+class LocalParser implements ParserInterface
+{
+
+    private ?ElementFinderInterface $last;
+    /**
+     * @var callable
+     */
+    private $logger;
+
+    public function __construct(?callable $logger = null)
+    {
+        $this->logger = $logger ?: function ($url): void {
+        };
+    }
+
+    final public function get(string $url): ElementFinderInterface
+    {
+        call_user_func($this->logger, $url);
+        $this->last = new ElementFinder(file_get_contents(__DIR__ . '/' . $url));
+        return $this->last;
+    }
+
+    final public function post(string $url, array $options): ElementFinderInterface
+    {
+        call_user_func($this->logger, $url);
+        $this->last = new ElementFinder(file_get_contents(__DIR__ . '/' . $url));
+        return $this->last;
+    }
+
+    final public function getLastPage(): ?ElementFinderInterface
+    {
+        return $this->last;
+    }
+}

--- a/tests/Dummy/a.html
+++ b/tests/Dummy/a.html
@@ -1,0 +1,13 @@
+<html>
+    <h1>
+        a
+    </h1>
+<div id="main">
+    <a href="b.html">b</a>
+    <a href="a.html">a</a>
+</div>
+<div id="a2">
+    <a href="c.html">b</a>
+    <a href="c.html">b</a>
+</div>
+</html>

--- a/tests/Dummy/b.html
+++ b/tests/Dummy/b.html
@@ -1,0 +1,5 @@
+<h1>b</h1>
+<div id="main">
+    <a href="d.html">d</a>
+</div>
+

--- a/tests/Dummy/c.html
+++ b/tests/Dummy/c.html
@@ -1,0 +1,5 @@
+<h1>c</h1>
+<div id="main">
+    <a href="c.html">c</a>
+</div>
+

--- a/tests/Dummy/d.html
+++ b/tests/Dummy/d.html
@@ -1,0 +1,5 @@
+<h1>d</h1>
+<div id="main">
+
+</div>
+

--- a/tests/Recursive/RecursiveParserTest.php
+++ b/tests/Recursive/RecursiveParserTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Test\Xparse\Parser\Recursive;
+
+use Test\Xparse\Parser\Dummy\LocalParser;
+use Xparse\Parser\Recursive\RecursiveParser;
+use PHPUnit\Framework\TestCase;
+
+final class RecursiveParserTest extends TestCase
+{
+    public function testAllLinks(): void
+    {
+        $links = [];
+        $logger = function ($link) use (&$links) {
+            $links[] = $link;
+        };
+        $pages = new RecursiveParser(
+            new LocalParser($logger),
+            ["//div[@id='main']/a/@href", "//div[@id='a2']/a/@href"],
+            ['a.html']
+        );
+        $h1 = [];
+        foreach ($pages as $page) {
+            $h1[] = $page->content('//h1')->replace('!\s!', '')->first();
+        }
+        self::assertSame([
+            'a.html', 'b.html', 'c.html', 'd.html'],
+            $links
+        );
+        self::assertSame(['a', 'b', 'c', 'd'],
+            $h1
+        );
+    }
+
+}


### PR DESCRIPTION
How this functional is different from the current Recursive Paginator implementation
1. We always accept list of expressions. 
2. We specify initial links in the constructor. 

```php
$pages = new RecursiveParser(
            $parser,
            ["//div[@id='main']/a/@href", "//div[@id='a2']/a/@href"], // 1. expressions
            ['a.html'] // 2. initial links
        );
```

3. Instead of nextPage we now use iterator approach:
```php
foreach($pages as $page){
//  .... 
}
```
